### PR TITLE
fix(示例与macOS): 修复macOS编译阻塞并补充Win32宏开关测试

### DIFF
--- a/example/01_basic_output.cpp
+++ b/example/01_basic_output.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 
 int main() {

--- a/example/02_color_output.cpp
+++ b/example/02_color_output.cpp
@@ -9,8 +9,7 @@
  * including global color macros, ColorController class, color wrapper classes,
  * and convenient color functions.
  */
-
-//#define TC_ENABLE_WIN32_CONSOLE_API  // 在 Windows 上强制启用 Windows 控制台 API，并禁用 ANSI 转义序列（不影响便捷颜色函数和其它平台）
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <iostream>
 #include <string>

--- a/example/03_font_styles.cpp
+++ b/example/03_font_styles.cpp
@@ -1,4 +1,4 @@
-// #define TC_ENABLE_WIN32_CONSOLE_API  // 在 Windows 上强制启用 Windows 控制台 API，并禁用 ANSI 转义序列（不影响便捷颜色函数和其它平台）
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 
 int main() {

--- a/example/04_delay_operations.cpp
+++ b/example/04_delay_operations.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 
 int main() {

--- a/example/05_progress_bar.cpp
+++ b/example/05_progress_bar.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 
 int main() {

--- a/example/06_cursor_control.cpp
+++ b/example/06_cursor_control.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 
 int main() {

--- a/example/07_terminal_size.cpp
+++ b/example/07_terminal_size.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 
 int main() {

--- a/example/08_key_wait.cpp
+++ b/example/08_key_wait.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <iostream>
 #include <string>

--- a/example/09_typewriter_effect.cpp
+++ b/example/09_typewriter_effect.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <string>
 

--- a/example/10_color_menu.cpp
+++ b/example/10_color_menu.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <vector>
 #include <string>

--- a/example/11_animation_effects.cpp
+++ b/example/11_animation_effects.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <vector>
 #include <string>

--- a/example/12_system_info.cpp
+++ b/example/12_system_info.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <string>
 

--- a/example/13_file_loading_progress.cpp
+++ b/example/13_file_loading_progress.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <fstream>
 #include <vector>

--- a/example/14_color_logger.cpp
+++ b/example/14_color_logger.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <string>
 #include <sstream>

--- a/example/15_interactive_cli.cpp
+++ b/example/15_interactive_cli.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <string>
 #include <vector>

--- a/example/16_snake_game.cpp
+++ b/example/16_snake_game.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <vector>
 #include <string>

--- a/example/17_guess_number_game.cpp
+++ b/example/17_guess_number_game.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <random>
 

--- a/example/18_game_menu.cpp
+++ b/example/18_game_menu.cpp
@@ -1,3 +1,4 @@
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 #include "../include/tc.hpp"
 #include <vector>
 #include <string>

--- a/example/19_painting_game.cpp
+++ b/example/19_painting_game.cpp
@@ -11,6 +11,7 @@
  * Users can move the cursor with arrow keys, draw or erase with space key,
  * and exit with ESC key.
  */
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 
 #include "../include/tc.hpp"
 #include <iostream>

--- a/example/20_terminal_printer_demo.cpp
+++ b/example/20_terminal_printer_demo.cpp
@@ -9,6 +9,7 @@
  * and Printer chain class to control the terminal, including clearing the screen,
  * moving the cursor, getting terminal size, etc.
  */
+#define TC_ENABLE_WIN32_CONSOLE_API  // 强制启用 Win32 Console API 宏（用于跨平台行为测试）
 
 #include "../include/tc.hpp"
 #include <iostream>

--- a/include/tc_print.hpp
+++ b/include/tc_print.hpp
@@ -59,6 +59,10 @@ inline void print(Args&&... args) {
     (detail::print_one(std::forward<Args>(args)), ...);
 }
 
+inline PrintProxy print() {
+    return PrintProxy();
+}
+
 template<typename... Args>
 inline void println(Args&&... args) {
     (detail::print_one(std::forward<Args>(args)), ...);
@@ -68,7 +72,7 @@ inline void println(Args&&... args) {
 /**
  * 返回一个PrintProxy对象用于链式调用
  */
-inline PrintProxy printer() {
+inline PrintProxy printProxy() {
     return PrintProxy();
 }
 

--- a/include/tc_system.hpp
+++ b/include/tc_system.hpp
@@ -35,6 +35,10 @@
 // Linux/Unix 平台相关头文件
 #include <sys/utsname.h>
 #include <unistd.h>
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#include <sys/sysctl.h>
+#endif
 #endif
 
 // --- 系统环境宏定义 | System environment macro definitions ---
@@ -244,8 +248,6 @@ namespace tc {
 
         // macOS/iOS 平台检测
         #elif defined(__APPLE__)
-            #include <TargetConditionals.h>
-
             // 首先尝试使用系统命令获取设备类型和操作系统信息
             std::string deviceType = executeCommand("uname -m");
             std::string productType = executeCommand("sw_vers -productName 2>/dev/null");
@@ -270,7 +272,6 @@ namespace tc {
                 }
 
                 // 如果系统命令失败，回退到使用sysctlbyname
-                #include <sys/sysctl.h>
                 char str[256];
                 size_t size = sizeof(str);
                 int ret = sysctlbyname("kern.osrelease", str, &size, NULL, 0);
@@ -300,7 +301,6 @@ namespace tc {
             // 检查是否为iOS/iPadOS/watchOS/tvOS等
 
             // 使用sysctl获取设备型号和系统信息
-            #include <sys/sysctl.h>
             char buffer[256];
             size_t size = sizeof(buffer);
 


### PR DESCRIPTION
## 变更说明

本 PR 主要用于完成 macOS 下 example 示例验证，并补充 `TC_ENABLE_WIN32_CONSOLE_API` 宏开关在 macOS 的对比测试。

### 1) 修复 macOS 编译阻塞（最小改动）
- `include/tc_print.hpp`
  - 新增 `print()` 零参数重载返回 `PrintProxy`，匹配示例中的链式写法。
  - 将 `printer()` 改名为 `printProxy()`，避免与 `tc_terminal.hpp` 中 `printer()` 返回类型冲突导致重载报错。
- `include/tc_system.hpp`
  - 将 Apple 平台相关头文件包含移动到文件级作用域，避免函数体内包含系统头引发的编译错误。

### 2) 宏开关对比测试
- 在 `example/01~20` 的 cpp 头部统一加入 `#define TC_ENABLE_WIN32_CONSOLE_API`，用于与“未定义宏”版本做对比验证。

## macOS 测试结论
- 宏 `TC_ENABLE_WIN32_CONSOLE_API` 在 macOS 上开/关结果一致，未观察到功能差异（该宏逻辑主要作用于 Windows 分支）。
- 额外观察到：`19_painting_game` 在 macOS 下 ESC 退出行为异常（与该宏无关）。

## 影响范围
- `include/tc_print.hpp`
- `include/tc_system.hpp`
- `example/01_basic_output.cpp` ~ `example/20_terminal_printer_demo.cpp`
